### PR TITLE
Don't double build dependabot branches

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches-ignore:
       - 'pulls/**'
+      - 'dependabot/**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
The tests run against all branches that get pushed, instead we should ignore dependabot branches because they are built as PRs