### PR TITLE
Remove body from HttpLike

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,34 +170,6 @@
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
-          "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/visitor-keys": "5.37.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-          "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
-          "dev": true
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-          "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
       }
     },
     "@typescript-eslint/parser": {
@@ -232,39 +204,6 @@
         "@typescript-eslint/utils": "5.37.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/types": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-          "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-          "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/visitor-keys": "5.37.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-          "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
       }
     },
     "@typescript-eslint/types": {
@@ -300,49 +239,6 @@
         "@typescript-eslint/typescript-estree": "5.37.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
-          "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/visitor-keys": "5.37.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-          "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-          "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "@typescript-eslint/visitor-keys": "5.37.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.37.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-          "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.37.0",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
       }
     },
     "@typescript-eslint/visitor-keys": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint -c .eslintrc ./src/**/*.ts ./test/**/*.ts",
+    "lint:fix": "npm run lint --silent -- --fix",
     "prepare": "npm run build",
     "preversion": "npm run lint",
     "test": "mocha -r ts-node/register test/**/*.ts"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,6 @@ type HttpLike = {
     method: string,
     url: string,
     headers: Record<string, { toString(): string } | string | string[] | undefined>,
-    body?: string | Buffer,
 }
 
 export type RequestLike = HttpLike;

--- a/test/httpbis/httpbis.ts
+++ b/test/httpbis/httpbis.ts
@@ -149,7 +149,6 @@ describe('httpbis', () => {
                 'Digest': 'SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=',
                 'Content-Length': '18',
             },
-            body: '{"hello": "world"}',
         };
         it('constructs minimal example', () => {
             const components: Component[] = [];


### PR DESCRIPTION
There is no need for the body prop as signatures are not concerned with the body of the request.

All data required for signing/verifying http-signatures are based in the request line and headers.

As discussed in other issues, the library should have a clearly defined remit, and that is simply to generate the signature header and to validate signature headers.

Other steps that may be related to signatures but not actually part of the signing process should be handled separately (eg: calculating body digests).