### PR TITLE
Add header extraction test based on spec

### DIFF
--- a/src/httpbis/index.ts
+++ b/src/httpbis/index.ts
@@ -25,11 +25,10 @@ export function extractHeader({ headers }: RequestLike | ResponseLike, header: s
     if (!allowMissing && !key) {
         throw new Error(`Unable to extract header "${header}" from message`);
     }
-    let val = key ? headers[key] ?? '' : '';
-    if (Array.isArray(val)) {
-        val = val.join(', ');
-    }
-    return val.toString().replace(/\s+/g, ' ');
+    const val = key ? headers[key] ?? '' : '';
+    return (!Array.isArray(val) ? [val] : val).map((v) => {
+        return v.toString().trim().replace(/\n+\s*/g, ' ');
+    }).join(', ');
 }
 
 function populateDefaultParameters(parameters: Parameters) {

--- a/src/httpbis/index.ts
+++ b/src/httpbis/index.ts
@@ -27,7 +27,7 @@ export function extractHeader({ headers }: RequestLike | ResponseLike, header: s
     }
     const val = key ? headers[key] ?? '' : '';
     return (!Array.isArray(val) ? [val] : val).map((v) => {
-        return v.toString().trim().replace(/\n+\s*/g, ' ');
+        return v.toString().trim().replace(/\n+\s*/g, ' ') || ' ';
     }).join(', ');
 }
 

--- a/test/httpbis/httpbis.ts
+++ b/test/httpbis/httpbis.ts
@@ -28,14 +28,18 @@ describe('httpbis', () => {
             }, {});
             expect(parsed).to.deep.equal(expected);
         });
+        it('extracts an empty header', () => {
+            const parsed = extractHeader({ headers: { 'x-empty-header': '' } } as unknown as RequestLike, 'x-empty-header');
+            expect(parsed).to.equal(' ');
+        });
         it('allows missing headers to return by default', () => {
-            expect(extractHeader({ headers } as unknown as RequestLike, 'missing')).to.equal('');
+            expect(extractHeader({ headers } as unknown as RequestLike, 'missing')).to.equal(' ');
         });
         it('throws on missing headers', () => {
             expect(() => extractHeader({ headers } as unknown as RequestLike, 'missing', { allowMissing: false })).to.throw(Error, 'Unable to extract header "missing" from message');
         });
         it('does not throw on missing headers', () => {
-            expect(extractHeader({ headers } as unknown as RequestLike, 'missing', { allowMissing: true })).to.equal('');
+            expect(extractHeader({ headers } as unknown as RequestLike, 'missing', { allowMissing: true })).to.equal(' ');
         });
     });
     describe('.extractComponent', () => {


### PR DESCRIPTION
Fixes an issue where headers are not extracted as per the spec: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#section-2.1