### PR TITLE
fix: remove spaces between comma separated values in the cavage signature header

### DIFF
--- a/src/cavage/index.ts
+++ b/src/cavage/index.ts
@@ -190,7 +190,7 @@ export async function signMessage<T extends Request | Response = Request | Respo
         }),
         `headers="${headerNames.join(' ')}"`,
         `signature="${signature.toString('base64')}"`,
-    ].join(', ');
+    ].join(',');
     return {
         ...message,
         headers: {

--- a/test/cavage/new.spec.ts
+++ b/test/cavage/new.spec.ts
@@ -347,7 +347,7 @@ describe('cavage', () => {
                     'Content-Type': 'application/json',
                     'Digest': 'SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=',
                     'Content-Length': '18',
-                    'Signature': 'keyId="rsa-key-1", algorithm="hs2019", created=1402170695, expires=1402170995, headers="(request-target) (created) (expires) host digest content-length", signature="YSBmYWtlIHNpZ25hdHVyZQ=="',
+                    'Signature': 'keyId="rsa-key-1",algorithm="hs2019",created=1402170695,expires=1402170995,headers="(request-target) (created) (expires) host digest content-length",signature="YSBmYWtlIHNpZ25hdHVyZQ=="',
                 });
                 expect(signer.sign).to.have.been.calledOnceWithExactly(Buffer.from(
                     '(request-target): post /foo\n' +
@@ -388,7 +388,7 @@ describe('cavage', () => {
                     'Date': 'Tue, 20 Apr 2021 02:07:56 GMT',
                     'Content-Type': 'application/json',
                     'Content-Length': '62',
-                    'Signature': 'created=1618884479, keyId="test-key-ecc-p256", headers="content-length content-type", signature="YSBmYWtlIHNpZ25hdHVyZQ=="',
+                    'Signature': 'created=1618884479,keyId="test-key-ecc-p256",headers="content-length content-type",signature="YSBmYWtlIHNpZ25hdHVyZQ=="',
                 });
                 expect(signer.sign).to.have.been.calledOnceWithExactly(Buffer.from(
                     'content-length: 62\n' +


### PR DESCRIPTION
Some of the examples are ambiguous about whether spaces should be in the signature header or not, but the v0 of this library didn't have them, and this makes v1 continue that style.