### PR TITLE
fix: use undecoded @path, @query and @query-param according to the spec

### DIFF
--- a/src/httpbis/index.ts
+++ b/src/httpbis/index.ts
@@ -93,7 +93,9 @@ export function deriveComponent(component: string, params: Map<string, string | 
                 throw new Error('Cannot derive @scheme on response');
             }
             const { pathname } = typeof context.url === 'string' ? new URL(context.url) : context.url;
-            return [decodeURI(pathname)];
+            // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#section-2.2.6
+            // empty path means use `/`
+            return [pathname || '/'];
         }
         case '@query': {
             if (!isRequest(context)) {
@@ -102,7 +104,7 @@ export function deriveComponent(component: string, params: Map<string, string | 
             const { search } = typeof context.url === 'string' ? new URL(context.url) : context.url;
             // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures#section-2.2.7
             // absent query params means use `?`
-            return [decodeURI(search) || '?'];
+            return [search || '?'];
         }
         case '@query-param': {
             if (!isRequest(context)) {
@@ -112,11 +114,11 @@ export function deriveComponent(component: string, params: Map<string, string | 
             if (!params.has('name')) {
                 throw new Error('@query-param must have a named parameter');
             }
-            const name = (params.get('name') as BareItem).toString();
+            const name = decodeURIComponent((params.get('name') as BareItem).toString());
             if (!searchParams.has(name)) {
                 throw new Error(`Expected query parameter "${name}" not found`);
             }
-            return searchParams.getAll(name);
+            return searchParams.getAll(name).map((value) => encodeURIComponent(value));
         }
         case '@status': {
             if (isRequest(context)) {

--- a/test/httpbis/httpbis.spec.ts
+++ b/test/httpbis/httpbis.spec.ts
@@ -170,9 +170,33 @@ describe('httpbis', () => {
                 ]);
                 expect(httpbis.deriveComponent('@path', new Map(), {
                     ...req,
+                    url: 'https://www.example.com/path%7D?param=value',
+                })).to.deep.equal([
+                    '/path%7D',
+                ]);
+                expect(httpbis.deriveComponent('@path', new Map(), {
+                    ...req,
+                    url: 'https://www.example.com',
+                })).to.deep.equal([
+                    '/',
+                ]);
+                expect(httpbis.deriveComponent('@path', new Map(), {
+                    ...req,
                     url: new URL(req.url as string),
                 })).to.deep.equal([
                     '/path',
+                ]);
+                expect(httpbis.deriveComponent('@path', new Map(), {
+                    ...req,
+                    url: new URL('https://www.example.com/path%7D?param=value'),
+                })).to.deep.equal([
+                    '/path%7D',
+                ]);
+                expect(httpbis.deriveComponent('@path', new Map(), {
+                    ...req,
+                    url: new URL('https://www.example.com'),
+                })).to.deep.equal([
+                    '/',
                 ]);
             });
             it('derives @query', () => {
@@ -198,6 +222,18 @@ describe('httpbis', () => {
                 })).to.deep.equal([
                     '?',
                 ]);
+                expect(httpbis.deriveComponent('@query', new Map(), {
+                    ...req,
+                    url: 'https://www.example.com//path?param=value&foo=bar&baz=bat%2Dman',
+                })).to.deep.equal([
+                    '?param=value&foo=bar&baz=bat%2Dman',
+                ]);
+                expect(httpbis.deriveComponent('@query', new Map(), {
+                    ...req,
+                    url: 'https://www.example.com/path',
+                })).to.deep.equal([
+                    '?',
+                ]);
                 // with URL objects
                 expect(httpbis.deriveComponent('@query', new Map(), {
                     ...req,
@@ -210,6 +246,12 @@ describe('httpbis', () => {
                     url: new URL('https://www.example.com/path?queryString'),
                 })).to.deep.equal([
                     '?queryString',
+                ]);
+                expect(httpbis.deriveComponent('@query', new Map(), {
+                    ...req,
+                    url: new URL('https://www.example.com//path?param=value&foo=bar&baz=bat%2Dman'),
+                })).to.deep.equal([
+                    '?param=value&foo=bar&baz=bat%2Dman',
                 ]);
                 expect(httpbis.deriveComponent('@query', new Map(), {
                     ...req,
@@ -242,6 +284,31 @@ describe('httpbis', () => {
                     'value',
                     'value2',
                 ]);
+                expect(httpbis.deriveComponent('@query-param', new Map([['name', 'param']]), {
+                    ...req,
+                    url: 'https://example.com/path?param=value%7D&param=value2%7D',
+                })).to.deep.equal([
+                    'value%7D',
+                    'value2%7D',
+                ]);
+                expect(httpbis.deriveComponent('@query-param', new Map([['name', 'var']]), {
+                    ...req,
+                    url: 'https://example.com/parameters?var=this%20is%20a%20big%0Amultiline%20value&bar=with+plus+whitespace&fa%C3%A7ade%22%3A%20=something',
+                })).to.deep.equal([
+                    'this%20is%20a%20big%0Amultiline%20value',
+                ]);
+                expect(httpbis.deriveComponent('@query-param', new Map([['name', 'bar']]), {
+                    ...req,
+                    url: 'https://example.com/parameters?var=this%20is%20a%20big%0Amultiline%20value&bar=with+plus+whitespace&fa%C3%A7ade%22%3A%20=something',
+                })).to.deep.equal([
+                    'with%20plus%20whitespace',
+                ]);
+                expect(httpbis.deriveComponent('@query-param', new Map([['name', 'fa%C3%A7ade%22%3A%20']]), {
+                    ...req,
+                    url: 'https://example.com/parameters?var=this%20is%20a%20big%0Amultiline%20value&bar=with+plus+whitespace&fa%C3%A7ade%22%3A%20=something',
+                })).to.deep.equal([
+                    'something',
+                ]);
                 // with URL objects
                 expect(httpbis.deriveComponent('@query-param', new Map([['name', 'baz']]), {
                     ...req,
@@ -267,6 +334,31 @@ describe('httpbis', () => {
                 })).to.deep.equal([
                     'value',
                     'value2',
+                ]);
+                expect(httpbis.deriveComponent('@query-param', new Map([['name', 'param']]), {
+                    ...req,
+                    url: new URL('https://example.com/path?param=value%7D&param=value2%7D'),
+                })).to.deep.equal([
+                    'value%7D',
+                    'value2%7D',
+                ]);
+                expect(httpbis.deriveComponent('@query-param', new Map([['name', 'var']]), {
+                    ...req,
+                    url: new URL('https://example.com/parameters?var=this%20is%20a%20big%0Amultiline%20value&bar=with+plus+whitespace&fa%C3%A7ade%22%3A%20=something'),
+                })).to.deep.equal([
+                    'this%20is%20a%20big%0Amultiline%20value',
+                ]);
+                expect(httpbis.deriveComponent('@query-param', new Map([['name', 'bar']]), {
+                    ...req,
+                    url: new URL('https://example.com/parameters?var=this%20is%20a%20big%0Amultiline%20value&bar=with+plus+whitespace&fa%C3%A7ade%22%3A%20=something'),
+                })).to.deep.equal([
+                    'with%20plus%20whitespace',
+                ]);
+                expect(httpbis.deriveComponent('@query-param', new Map([['name', 'fa%C3%A7ade%22%3A%20']]), {
+                    ...req,
+                    url: new URL('https://example.com/parameters?var=this%20is%20a%20big%0Amultiline%20value&bar=with+plus+whitespace&fa%C3%A7ade%22%3A%20=something'),
+                })).to.deep.equal([
+                    'something',
                 ]);
             });
             it('derives @status', () => {


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures-19#name-path
https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures-19#name-query