### PR TITLE
chore(deps): bump structured-headers from 1.0.1 to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
-        "structured-headers": "^1.0.1"
+        "structured-headers": "^2.0.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.6.7",
@@ -9855,11 +9855,12 @@
       }
     },
     "node_modules/structured-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-1.0.1.tgz",
-      "integrity": "sha512-QYBxdBtA4Tl5rFPuqmbmdrS9kbtren74RTJTcs0VSQNVV5iRhJD4QlYTLD0+81SBwUQctjEQzjTRI3WG4DzICA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-2.0.2.tgz",
+      "integrity": "sha512-IUul56vVHuMg2UxWhwDj9zVJE6ztYEQQkynr1FQ/NydPhivtk5+Qb2N1RS36owEFk2fNUriTguJ2R7htRObcdA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 14",
+        "node": ">=18",
         "npm": ">=6"
       }
     },
@@ -17607,9 +17608,9 @@
       "dev": true
     },
     "structured-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-1.0.1.tgz",
-      "integrity": "sha512-QYBxdBtA4Tl5rFPuqmbmdrS9kbtren74RTJTcs0VSQNVV5iRhJD4QlYTLD0+81SBwUQctjEQzjTRI3WG4DzICA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-2.0.2.tgz",
+      "integrity": "sha512-IUul56vVHuMg2UxWhwDj9zVJE6ztYEQQkynr1FQ/NydPhivtk5+Qb2N1RS36owEFk2fNUriTguJ2R7htRObcdA=="
     },
     "super-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "typescript": "^5.0.3"
   },
   "dependencies": {
-    "structured-headers": "^1.0.1"
+    "structured-headers": "^2.0.2"
   }
 }

--- a/src/httpbis/index.ts
+++ b/src/httpbis/index.ts
@@ -5,12 +5,11 @@ import {
     serializeItem,
     serializeList,
     Dictionary as DictionaryType,
-    ByteSequence,
     serializeDictionary,
     parseList,
     Parameters,
     isInnerList,
-    isByteSequence,
+    arrayBufferToBase64,
     Token,
 } from 'structured-headers';
 import { Dictionary, parseHeader, quoteString } from '../structured-header';
@@ -176,12 +175,16 @@ export function extractHeader(header: string, params: Map<string, string | numbe
 function normaliseParams(params: Parameters): Map<string, string | number | boolean> {
     const map = new Map<string, string | number | boolean>;
     params.forEach((value, key) => {
-        if (value instanceof ByteSequence) {
-            map.set(key, value.toBase64());
+        if (value instanceof ArrayBuffer) {
+            map.set(key, arrayBufferToBase64(value));
         } else if (value instanceof Token) {
             map.set(key, value.toString());
-        } else {
+        } else if (value instanceof Date) {
+            map.set(key, Math.floor(value.getTime() / 1000));
+        } else if (typeof value === 'number' || typeof value === 'string' || typeof value === 'boolean') {
             map.set(key, value);
+        } else {
+            map.set(key, value.toString());
         }
     });
     return map;
@@ -302,7 +305,7 @@ export function augmentHeaders(headers: Record<string, string | string[]>, signa
         signatureName += count.toString();
     }
     // append our signature and signature-inputs to the headers and return
-    signatureHeader.set(signatureName, [new ByteSequence(signature.toString('base64')), new Map()]);
+    signatureHeader.set(signatureName, [signature.buffer.slice(signature.byteOffset, signature.byteOffset + signature.byteLength), new Map()]);
     inputHeader.set(signatureName, parseList(signatureInput)[0]);
     return {
         ...headers,
@@ -370,9 +373,9 @@ export async function verifyMessage(config: VerifyConfig, message: Request | Res
     const requiredFields = config.requiredFields ?? [];
     return Array.from(signatureInputs.entries()).reduce<Promise<boolean | null>>(async (prev, [name, input]) => {
         const signatureParams: SignatureParameters = Array.from(input[1].entries()).reduce((params, [key, value]) => {
-            if (value instanceof ByteSequence) {
+            if (value instanceof ArrayBuffer) {
                 Object.assign(params, {
-                    [key]: value.toBase64(),
+                    [key]: arrayBufferToBase64(value),
                 });
             } else if (value instanceof Token) {
                 Object.assign(params, {
@@ -443,9 +446,9 @@ export async function verifyMessage(config: VerifyConfig, message: Request | Res
         if (!signature) {
             throw new MalformedSignatureError('No corresponding signature for input');
         }
-        if (!isByteSequence(signature[0] as BareItem)) {
+        if (!(signature[0] instanceof ArrayBuffer)) {
             throw new MalformedSignatureError('Malformed signature');
         }
-        return key.verify(Buffer.from(base), Buffer.from((signature[0] as ByteSequence).toBase64(), 'base64'), signatureParams);
+        return key.verify(Buffer.from(base), Buffer.from(signature[0] as ArrayBuffer), signatureParams);
     }, Promise.resolve(null));
 }


### PR DESCRIPTION
Upgrades the `structured-headers` runtime dependency to v2.0.0.

## Changes in structured-headers v2

- `ByteSequence` class removed → replaced with native `ArrayBuffer`
- `isByteSequence()` removed → use `instanceof ArrayBuffer`
- New utility exports: `arrayBufferToBase64()` / `base64ToArrayBuffer()`
- `BareItem` type widened to include `Date` and `DisplayString`
- Adds RFC 9651 support (Date and Display String structured field types)
- Ships both ESM and CJS builds

## Code changes

All changes are in `src/httpbis/index.ts`:

- Replaced `ByteSequence` / `isByteSequence` imports with `arrayBufferToBase64`
- Updated `normaliseParams()` to handle new `Date` and `DisplayString` bare item types
- Updated `augmentHeaders()` to use direct Buffer→ArrayBuffer conversion instead of base64 round-trip
- Updated `verifyMessage()` to use `instanceof ArrayBuffer` and `Buffer.from(ArrayBuffer)`

No public API changes — this is fully internal.

Supersedes #179.
