### PR TITLE
ci: run workflow actions on Node.js 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,8 @@ updates:
           - "sinon-chai"
           - "@types/sinon-chai"
           - "mockdate"
+  - package-ecosystem: "github-actions" # Keep workflow action versions up to date
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18.x
           cache: 'npm'
@@ -40,11 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 18.x
           cache: 'npm'
@@ -63,11 +63,11 @@ jobs:
         node-version: [16.x, 18.x, 20.x, 22.x]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -82,11 +82,11 @@ jobs:
       - commitlint
       - codelint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: 'npm'
@@ -115,11 +115,11 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "22.x"
           cache: 'npm'


### PR DESCRIPTION
## What

Bumps `actions/checkout` and `actions/setup-node` from `v3` to `v6` across all jobs in `nodejs.yml`, and adds the `github-actions` ecosystem to Dependabot.

## Why

CI was emitting:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v3, actions/setup-node@v3.

`v3` of both actions runs on the now-deprecated Node.js 20 runtime. GitHub will force these to Node.js 24 from **2026-06-16** and remove Node.js 20 on **2026-09-16**. `v6` of both actions runs on Node.js 24, clearing the warning.

The root cause of the drift is that Dependabot only tracked `npm`, so the actions were never auto-bumped. Adding the `github-actions` ecosystem prevents this recurring.

## Notes

- All jobs already set `cache: 'npm'` explicitly, so the automatic package-manager caching introduced in `setup-node@v5` has no effect here.
- `setup-node` still installs the Node versions in the test matrix (16/18/20/22) regardless of the runtime the action itself runs on.

## Verification

- Both workflow and Dependabot YAML validated.
- `commitlint` passes on both commits.