### PR TITLE
ci: test against Node.js 24

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -60,7 +60,7 @@ jobs:
       - codelint
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## What

Adds `24.x` to the `test` job's Node.js matrix (now `[16.x, 18.x, 20.x, 22.x, 24.x]`).

## Why

Node.js 24 became active LTS in October 2025 but wasn't covered by CI — the matrix only went up to 22.x. Since this library touches Node's `crypto` internals (which shift between majors), exercising the current LTS on every run is worthwhile.

## Verification

- Full test suite (197 passing) runs green locally on Node v24.16.0, with no source or type changes required (tsconfig still targets node16).
- Workflow YAML validated.

No `engines` field is declared, so this only adds coverage; trimming the EOL lines (16/18/20) is left as a separate maintainer decision.