### PR TITLE
ci: ignore typescript semver-major until tseslint supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,13 @@ updates:
           - "sinon-chai"
           - "@types/sinon-chai"
           - "mockdate"
+    ignore:
+      # TypeScript 7 (native compiler) is not yet supported by
+      # @typescript-eslint, which peers typescript ">=4.8.4 <6.1.0". Bumping the
+      # major makes `npm ci` fail with ERESOLVE, breaking the lint jobs. Hold the
+      # major until the lint toolchain supports TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions" # Keep workflow action versions up to date
     directory: "/"
     schedule:


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` rule for **typescript** `version-update:semver-major` in the npm ecosystem.

## Why

TypeScript 7 ships a new native compiler, but `@typescript-eslint` still peers `typescript ">=4.8.4 <6.1.0"`. The `build-tools` group bump to `typescript@7` (#229) makes `npm ci` fail with `ERESOLVE`, which breaks both lint jobs:

```
npm error Found: typescript@7.0.2
npm error peer typescript@">=4.8.4 <6.1.0" from @typescript-eslint/eslint-plugin@8.65.0
```

This is the same ecosystem block seen across the org (e.g. azure-middleware TS 6→7). Ignoring the **major** lets the `build-tools` group keep bumping `@types/node` and friends without being dragged onto an unsupported TypeScript. Revisit once `@typescript-eslint` supports TypeScript 7.

## Follow-up

After this merges, Dependabot will recreate the `build-tools` group PR without the typescript major, superseding #229 (which can then be closed).