### PR TITLE
ci: ignore @types/node semver-major to match supported node floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,13 @@ updates:
       # major until the lint toolchain supports TypeScript 7.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # @types/node is deliberately pinned to the oldest Node.js version this
+      # package supports (see the 16.x entry in the CI test matrix, and
+      # @tsconfig/node16). Taking a major would type-check the source against a
+      # newer runtime's APIs while CI still claims Node 16 support, so the major
+      # is only moved when the support floor is raised.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions" # Keep workflow action versions up to date
     directory: "/"
     schedule:


### PR DESCRIPTION
Adds a Dependabot `ignore` rule for `@types/node` majors, alongside the existing `typescript` one.

### Why

Prompted by #239, which proposed `@types/node` **16.18.126 → 26.1.2**.

`@types/node` is deliberately pinned to the **oldest Node.js version this package supports**:

- `16.x` is still the first entry in the CI test matrix (`[16.x, 18.x, 20.x, 22.x, 24.x]`)
- the compiler is configured via `@tsconfig/node16`

Taking a major would type-check the source against a much newer runtime's API surface while CI still advertises Node 16 support — so the code could compile clean against APIs that simply don't exist on the oldest runtime we claim to support.

### Why a rule rather than another ignore comment

#239 already carries **six** accumulated ignore conditions:

| Dependency | Ignore conditions |
| --- | --- |
| @types/node | `>= 13.a, < 14` · `>= 14.a, < 15` · `>= 15.a, < 16` · `>= 17.a, < 18` · `>= 18.a, < 19` · `>= 20.a, < 21` |

Those came from one-off `@dependabot ignore this major version` comments, and each suppresses exactly **one** major — so a fresh PR reappears with every DefinitelyTyped major release. `update-types: ["version-update:semver-major"]` holds all of them at once, permanently.

### Effect

Minor and patch `@types/node` updates keep flowing within the `16.x` line. Only majors are held, and the rule is dropped whenever the support floor is deliberately raised.

Closes #239.
